### PR TITLE
Fixed typos  names: useAverageBlockTime, useAverageFees, loadingAvеra…

### DIFF
--- a/services/explorer-ui/src/hooks/stats.ts
+++ b/services/explorer-ui/src/hooks/stats.ts
@@ -22,16 +22,16 @@ export const useTotalContracts = (): UseQueryResult<string, Error> => {
   });
 };
 
-export const useAvarageFees = (): UseQueryResult<string, Error> => {
+export const useAverageFees = (): UseQueryResult<string, Error> => {
   return useQuery<string, Error>({
-    queryKey: ["useAvarageFees"],
+    queryKey: ["useAverageFees"],
     queryFn: statsL2Api.getL2AverageFees,
   });
 };
 
-export const useAvarageBlockTime = (): UseQueryResult<string, Error> => {
+export const useAverageBlockTime = (): UseQueryResult<string, Error> => {
   return useQuery<string, Error>({
-    queryKey: ["useAvarageBlockTime"],
+    queryKey: ["useAverageBlockTime"],
     queryFn: statsL2Api.getL2AverageBlockTime,
   });
 };

--- a/services/explorer-ui/src/pages/landing/index.tsx
+++ b/services/explorer-ui/src/pages/landing/index.tsx
@@ -3,8 +3,8 @@ import { BlocksTable } from '~/components/blocks/blocks-table';
 import { TxEffectsTable } from '~/components/tx-effects/tx-effects-table';
 import { useLatestBlocks } from '~/hooks';
 import {
-  useAvarageBlockTime,
-  useAvarageFees,
+  useAverageBlockTime,
+  useAverageFees,
   useTotalContracts,
   useTotalTxEffects,
   useTotalTxEffectsLast24h,
@@ -24,20 +24,20 @@ export const Landing: FC = () => {
     error: errorTotalEffects24h,
   } = useTotalTxEffectsLast24h();
   const {
-    data: avarageFees,
-    isLoading: loadingAvarageFees,
-    error: errorAvarageFees,
-  } = useAvarageFees();
+    data: averageFees,
+    isLoading: loadingAverageFees,
+    error: errorAverageFees,
+  } = useAverageFees();
   const {
     data: totalAmountOfContracts,
     isLoading: loadingAmountContracts,
     error: errorAmountContracts,
   } = useTotalContracts();
   const {
-    data: avarageBlockTime,
-    isLoading: loadingAvarageBlockTime,
-    error: errorAvarageBlockTime,
-  } = useAvarageBlockTime();
+    data: averageBlockTime,
+    isLoading: loadingAverageBlockTime,
+    error: errorAverageBlockTime,
+  } = useAverageBlockTime();
 
   if (isLoading) return <p>Loading...</p>;
   if (error) return <p className="text-red-500">{error.message}</p>;
@@ -82,14 +82,14 @@ export const Landing: FC = () => {
         </div>
         <div className="bg-white w-3/12 rounded-lg shadow-md p-4">
           <p>Average fee's</p>
-          {getStatsData(loadingAvarageFees, errorAvarageFees, avarageFees)}
+          {getStatsData(loadingAverageFees, errorAverageFees, averageFees)}
         </div>
         <div className="bg-white w-3/12 rounded-lg shadow-md p-4">
           <p>Average block time</p>
           {getStatsData(
-            loadingAvarageBlockTime,
-            errorAvarageBlockTime,
-            avarageBlockTime,
+            loadingAverageBlockTime,
+            errorAverageBlockTime,
+            averageBlockTime,
           )}
           ms
         </div>


### PR DESCRIPTION
Fixed typos  names: useAverageBlockTime, useAverageFees, loadingAvеrageFees, errorAvеrageFees, avеrageFees