### PR TITLE
Typo constants.ts

### DIFF
--- a/services/explorer-ui/src/pages/tx-effect-details/constants.ts
+++ b/services/explorer-ui/src/pages/tx-effect-details/constants.ts
@@ -23,7 +23,7 @@ export type Tab = z.infer<typeof tabSchema>;
 export const txEffectTabs: Tab[] = [
   { id: "ecryptedLogs", label: "Encrypted logs" },
   { id: "unencryptedLogs", label: "Unencrypted logs" },
-  { id: "noteEncryptedLogs", label: "Note encryped logs" },
+  { id: "noteEncryptedLogs", label: "Note encrypted logs" },
   { id: "nullifiers", label: "Nullifiers" },
   { id: "noteHashes", label: "Note hashes" },
   { id: "l2ToL1Msgs", label: "L2 to L1 messages" },


### PR DESCRIPTION
# Pull Request

## Title

Fix Typo in `constants.ts`: Corrected "Note encryped logs" to "Note encrypted logs" for Better Clarity

## Description

This pull request fixes a typo in the `constants.ts` file, changing `Note encryped logs` to `Note encrypted logs`.

---
